### PR TITLE
fix(ci): group CodeQL actions to avoid failing CIs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,11 @@ updates:
       interval: "weekly"
     assignees:
       - "pandatix"
+    groups:
+      # init/autobuild/analyze must stay on the same version or CodeQL errors out
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   
   # Root Go module
   - package-ecosystem: "gomod"


### PR DESCRIPTION
This PR fixes the issue of having many CodeQL actions bumped in different PRs by dependabot (they need to be updated at once to properly work).